### PR TITLE
fix: update clean target to remove git-crypt.exe on Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ CLEAN_TARGETS := clean-bin $(CLEAN_MAN_TARGETS-$(ENABLE_MAN))
 clean: $(CLEAN_TARGETS)
 
 clean-bin:
-	rm -f $(OBJFILES) git-crypt
+	rm -f $(OBJFILES) git-crypt git-crypt.exe
 
 clean-man:
 	rm -f man/man1/git-crypt.1


### PR DESCRIPTION
Modify the clean target in the Makefile to ensure git-crypt.exe is removed on Windows systems.